### PR TITLE
Added missing apt-get instruction for libgmp3-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ git clone --recursive <this_repo>
 
 You *might* need to install these dependencies on Linux (for `cvxpy`'s SCS solver and to generate reasonably sized animation files) (did not need to on OSX):
 ```bash
-sudo apt-get install libblas-dev liblapack-dev gifsicle
+sudo apt-get install libblas-dev liblapack-dev gifsicle libgmp3-dev
 ```
 
 Create a `virtualenv` for this repo:


### PR DESCRIPTION
Add libgmp3-dev installation to readme, matching Dockerfile setup.